### PR TITLE
Improving make_julia_environment.jl: CI fix, unified issue handling

### DIFF
--- a/make_julia_environment.jl
+++ b/make_julia_environment.jl
@@ -1,4 +1,4 @@
-using Pkg, Logging
+using Pkg
 
 julia_pkg_list = [
     "ArgParse",


### PR DESCRIPTION
This PR fixes a bug in make_julia_environment.jl and unifies issue handling for CPLEX, other Julia libraries, and the Python packages.

### Fix for CI issue with ArgParse

A previous version of this file broke the CI workflow by introducing ArgParse as a required library for make_julia_environment.jl to run properly. This was added in order to allow a command-line argument invoking a "make clean" version of the script, which would automatically delete any preexisting Julia environment files found in the current directory. This was desirable because Julia will try to build on top of any extant environment files without checking to see if those files work properly.

I decided that the "make clean" version of make_julia_environment.jl should be the default script behavior, and allowing the user to merely update the underlying environment files is probably not helpful for the vast majority of cases. The CL argument has been removed again and the script automatically deletes those environment files, meaning ArgParse can be removed from the script's requirements.

### Unified issue handling

To allow this script (and ABCE as a whole) to work on platforms where CPLEX cannot be installed, Sam Dotson implemented ABCE compatibility with various open-source solvers such as HiGHs. The make_julia_environment.jl script was also updated to allow graceful failure of the CPLEX installation step, merely providing a warning on the terminal rather than throwing an error.

This PR updates the handling of CPLEX by folding it into the more general error-handling procedure for required packages. All packages are installed and built in a `try ... catch` block; if an error occurs, the name of the package and the error are recorded and later shown to the user as warnings. CPLEX is now handled by this same method, rather than in a separate `try ... catch` block.

### Cleanup

This PR also improves the formatting of the final user message, and fits several very long strings appropriately into 80-character lines.