### PR TITLE
WIP: update Julia from 1.7.3 to 1.8.2

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -39,10 +39,10 @@ jobs:
       run: |
         pytest
 
-    - name: Set up Julia 1.7
+    - name: Set up Julia 1.8
       uses: julia-actions/setup-julia@v1
       with:
-        version: 1.7
+        version: 1.8
         arch: x86
     - name: Install Julia dependencies
       run: |


### PR DESCRIPTION
ABCE's only explicit specification for Julia version is currently in the workflow file. The installation script (see PR #18 ) will also explicitly download and install Julia 1.8, but for now these changes in `python_app.yml` are the only updates needed in the code to move to the newest version of Julia. Updating to Julia 1.8 didn't introduce any breaking changes.