### PR TITLE
Change install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -176,8 +176,6 @@ if [[ ! -f "${RC_FILE}" ]]; then
 fi
 
 # Create an associative array to allow looping over ABCE environment variables
-# declare -A env_vars
-# env_vars=( ["ABCE_DIR"]="$abce_dir" ["ALEAF_DIR"]="$aleaf_dir" )
 env_vars=( "ABCE_DIR=$abce_dir" "ALEAF_DIR=$aleaf_dir" )
 for var in "${env_vars[@]}"; do
     echo "export $var" >> "${RC_FILE}"


### PR DESCRIPTION
`declare -A` and `readarray -t` are Bash built-in command, if using a different shell(zsh/ksh).
 
Use a regular array instead of an associative array for `declare -A`
Change `readarray` with a combination of `grep`, `sed`, and `while`

