### PR TITLE
Adding a single-agent test version of the ERCOT market

### DIFF
--- a/inputs/single_agent_testing.yml
+++ b/inputs/single_agent_testing.yml
@@ -1,6 +1,9 @@
 # This is a dummy implementation of the ERCOT market, with all assets owned
 #   by the balance of system operator except for one of each type, which is
 #   owned by active agent #201.
+# This total system portfolio can serve a peak demand of around 75000 MW.
+#   Check your settings.yml file to make sure dispatch won't fail due to energy
+#   shortages.
 
 # Test agent
 201:


### PR DESCRIPTION
The eight-agent version of the ERCOT market takes a while to run, which is inconvenient when testing the code. This PR implements a dummy file with one active agent and one inactive balance-of-system agent. The active agent owns one of every unit type, with retirement periods about 10 years in the future, and the BOS agent owns everything else.

The user can select this file by changing the `file_paths`:`agent_specifications_file` value in `settings.yml` to `single_agent_testing.yml`.