### PR TITLE
Correcting indexing bug on future system portfolios

### DIFF
--- a/src/ABCEfunctions.jl
+++ b/src/ABCEfunctions.jl
@@ -373,7 +373,7 @@ function get_net_demand(
                      total_eff_cap = Float64[]
                  )
 
-    for i = pd:pd+maximum(keys(system_portfolios))
+    for i = pd:maximum(keys(system_portfolios))
         year_portfolio = innerjoin(
             system_portfolios[i],
             unit_specs,


### PR DESCRIPTION
This PR corrects a small bug in the `get_net_demand()` function. This function projects the reserve margin in future years by comparing the expected total system portfolio with expected peak demand. Some incorrect indices in the `for` loop caused the code to work when the current simulation period was 0, but not for periods 1 and beyond.

This PR sets the indices to begin at the current period and end at the maximum year for which the `system_portfolios` dictionary has a corresponding entry.