### PR TITLE
Fixing bug in debt paydown calculations

### DIFF
--- a/src/ABCEfunctions.jl
+++ b/src/ABCEfunctions.jl
@@ -925,7 +925,7 @@ function forecast_debt_schedule(
         if i != fin_end
             fs_copy[i + 1, :remaining_debt_principal] =
                 fs_copy[i, :remaining_debt_principal] -
-                fs_copy[i, :interest_payment]
+                (fs_copy[i, :debt_payment] - fs_copy[i, :interest_payment])
         end
     end
 


### PR DESCRIPTION
This PR fixes a bug in the progressive debt paydown calculations, to the corrected formula:

```
agent_fs[i+1, :remaining_debt_principal] = agent_fs[i, :remaining_debt_principal] - (agent_fs[i, :debt_payment] - agent_fs[i, :interest_payment])
```