### PR TITLE
Remove unnecessary reference to ALEAF settings in run.py setup

### DIFF
--- a/run.py
+++ b/run.py
@@ -55,8 +55,6 @@ def set_up_local_paths(settings):
             )
             logging.error(msg)
             raise
-    else:
-        settings["ALEAF"]["ALEAF_abs_path"] = Path("NULL_PATH")
 
     return settings
 


### PR DESCRIPTION
This PR allows ABCE to run without the ALEAF settings block in `settings.yml`. The removed line of code is irrelevant if ALEAF is not specified as the dispatch solver anyway, so this change does not alter any program behavior.