### PR TITLE
Updating some minor settings values

### DIFF
--- a/settings.yml
+++ b/settings.yml
@@ -6,7 +6,7 @@ simulation:
   C2N_assumption: baseline
 
 scenario:
-  peak_demand: 75000
+  peak_demand: 79000
   policies:
     CTAX:
       enabled: False
@@ -69,7 +69,7 @@ system:
 # Settings for demand projections
 demand:
   total_forecast_horizon: 10   # Number of periods in the complete forecast horizon
-  demand_visibility_horizon: 2
+  demand_visibility_horizon: 5
   demand_projection_mode: exp_termrate     # flat, exp_fitted, or exp_termrate
   demand_projection_window: 5 # Total number of periods used to project demand
   historical_demand_growth_rate: 0.01
@@ -86,7 +86,7 @@ dispatch:
 # Settings for agent behavior optimization
 agent_opt:
   num_future_periods_considered: 4    # Number of periods for which to consider future projects
-  max_type_rets_per_pd: 3
+  max_type_rets_per_pd: 5
   max_type_newbuilds_per_pd: 5
   shortage_protection_period: 8
   cap_decrease_threshold: 1.05


### PR DESCRIPTION
This PR updates values for a few settings:

* Peak demand: 75000 -> 79000
* Future demand visibility window: 2 -> 5 (should have been 5 all along)
* Maximum number of retirements per period per type per agent: 3 -> 5