### PR TITLE
Improving logging output during agent decision turns

### DIFF
--- a/src/ABCEfunctions.jl
+++ b/src/ABCEfunctions.jl
@@ -2231,23 +2231,34 @@ end
 function display_agent_choice_results(CLI_args, m, all_results)
     status = string(termination_status.(m))
     @debug "Model termination status: $status"
+    println("=== Results: ===")
 
     agent_id = CLI_args["agent_id"]
 
     if CLI_args["verbosity"] == 2
-        if status == "OPTIMAL"
-            units_to_execute = filter(:units_to_execute => u -> u > 0, all_results)
+        msg = nothing
+        units_to_execute = nothing
 
-            if size(units_to_execute)[1] == 0
-                @info "Agent $agent_id's optimal decision is to take no actions this turn."
+        if status == "OPTIMAL"
+            results = filter(:units_to_execute => u -> u > 0, all_results)
+
+            if size(results)[1] == 0
+                msg = "Agent $agent_id's optimal decision is to take no actions this turn."
             else
-                @info "Project alternatives to execute:"
-                @info filter(:units_to_execute => u -> u > 0, all_results)
+                msg = "Project alternatives to execute:"
+                units_to_execute = results
             end
         else
-            @info "No feasible solution found for the decision optimization problem."
-            @info "Agent $agent_id will take no actions this turn."
+            msg = "No feasible solution found for the decision optimization problem.\nAgent $agent_id will take no actions this turn."
         end
+
+        if msg != nothing
+            @info msg
+        end
+        if units_to_execute != nothing
+            @info units_to_execute
+        end
+
     elseif CLI_args["verbosity"] == 3
         @debug "Alternatives to execute:"
         @debug all_results

--- a/src/agent_choice.jl
+++ b/src/agent_choice.jl
@@ -90,6 +90,8 @@ end
 
 
 function run_agent_choice()
+    @info "Setting up data..."
+
     # Read in the command-line arguments
     CLI_args = ABCEfunctions.get_CL_args()
 
@@ -148,6 +150,7 @@ function run_agent_choice()
 
     # Use the agent's internal dispatch forecast generator to project dispatch
     #   results in the system over the forecast horizon
+    @info "Simulating future market dispatch..."
     dispatch_results = Dispatch.execute_dispatch_economic_projection(
         CLI_args,
         db,
@@ -160,6 +163,7 @@ function run_agent_choice()
 
     # Set up all available project alternatives, including computing marginal
     #   NPV for all potential projects (new construction and retirements)
+    @info "Setting up all project alternatives..."
     PA_uids, PA_fs_dict = ABCEfunctions.set_up_project_alternatives(
         settings,
         unit_specs,
@@ -174,6 +178,7 @@ function run_agent_choice()
 
     # Update the agent's baseline projected financial statements, to use in
     #   the decision optimization model
+    @debug "Updating the agent's financial statements..."
     agent_fs = ABCEfunctions.update_agent_financial_statement(
         settings,
         CLI_args["agent_id"],
@@ -186,6 +191,7 @@ function run_agent_choice()
     )
 
     # Set up the agent's decision optimization model
+    @info "Setting up the agent's decision optimization problem..."
     m = ABCEfunctions.set_up_model(
         settings,
         PA_uids,
@@ -203,9 +209,11 @@ function run_agent_choice()
     )
 
     # Solve the model
+    @info "Solving optimization problem..."
     optimize!(m)
 
     # Process the model outputs
+    @debug "Postprocessing model results..."
     process_results(settings, CLI_args, m, db, PA_uids, unit_specs)
 end
 


### PR DESCRIPTION
This PR adds some logging signposting during the agent decision turns, and makes the results slightly more explicit (i.e. stating directly whether a model was infeasible, or whether the agent optimally chose to take no actions).