### PR TITLE
Changing default number of repdays in main and examples settings

### DIFF
--- a/examples/multiple_agents_example/settings.yml
+++ b/examples/multiple_agents_example/settings.yml
@@ -79,7 +79,7 @@ demand:
 #   dispatch data
 dispatch:
   num_dispatch_years: 10  # Num. of years to explicitly simulate dispatch
-  num_repdays: 35
+  num_repdays: 25
   hist_wt: 0.4  # Weighting of historical versus projected data
   hist_decay: 0.5   # Decay factor for each historical data year
 

--- a/examples/single_agent_example/settings.yml
+++ b/examples/single_agent_example/settings.yml
@@ -79,7 +79,7 @@ demand:
 #   dispatch data
 dispatch:
   num_dispatch_years: 10  # Num. of years to explicitly simulate dispatch
-  num_repdays: 35
+  num_repdays: 25
   hist_wt: 0.4  # Weighting of historical versus projected data
   hist_decay: 0.5   # Decay factor for each historical data year
 

--- a/settings.yml
+++ b/settings.yml
@@ -79,7 +79,7 @@ demand:
 #   dispatch data
 dispatch:
   num_dispatch_years: 10  # Num. of years to explicitly simulate dispatch
-  num_repdays: 35
+  num_repdays: 45
   hist_wt: 0.4  # Weighting of historical versus projected data
   hist_decay: 0.5   # Decay factor for each historical data year
 


### PR DESCRIPTION
Previously, both the top-level settings file and the example-run settings files contained 35 as the default number of representative days. This PR adjusts this default value:

* to 45 repdays in the top-level settings file, for increased simulation fidelity
* to 25 repdays in the settings files for the example cases, to increase execution speed