### PR TITLE
Fixing bug with NaNs in unit_specs due to C2N projects

### DIFF
--- a/src/postprocessing.py
+++ b/src/postprocessing.py
@@ -105,7 +105,7 @@ def get_portfolio_profile(settings, db, agent_id, unit_specs):
     # Set the total time horizon to num_steps + the construction duration of
     #   the fastest-to-build project
     horizon = int(
-        min(unit_specs.construction_duration)
+        unit_specs.construction_duration.min(skipna=True)
         + int(settings["simulation"]["num_steps"])
         + 1
     )


### PR DESCRIPTION
Previously, postprocessing would fail if a C2N project was the first unit in the `unit_specs` table. This is because C2N projects are declared in `unit_specs.yml` without preset values for `construction_duration`, so their corresponding value in the `unit_specs` table is NaN. The NaN value would cause a certain calculation over a `unit_specs` column to fail if the first value in the column was NaN.

This PR fixes the issue by using a method which ignores NaN values.

This PR is related to #95 but doesn't close the issue.