### PR TITLE
Add optional verbose output logging for intermediate calculation results

### DIFF
--- a/run.py
+++ b/run.py
@@ -111,13 +111,6 @@ def cli_args():
         help="Disable plot generation during postprocessing (prevents matplotlib/qt issues)",
     )
 
-    parser.add_argument(
-        "--verbose_outputs",
-        "-O",
-        action="store_true",
-        help="Save various intermediate calculation results to the tmp/ directory",
-    )
-
     args = parser.parse_args()
     return args
 

--- a/src/ABCEfunctions.jl
+++ b/src/ABCEfunctions.jl
@@ -68,11 +68,6 @@ function get_CL_args()
         required = true
         arg_type = String
 
-        "--verbose_outputs"
-        help = "if True, store various intermediate calculation results in the tmp/ directory"
-        required = false
-        arg_type = Int
-        default = 0
     end
 
     return parse_args(s)
@@ -552,7 +547,7 @@ function set_up_project_alternatives(
     current_pd,
     C2N_specs,
     dispatch_results,
-    verbose_outputs,
+    verbosity,
 )
     PA_summaries = create_PA_summaries(settings, unit_specs, asset_counts)
     PA_fs_dict = Dict()
@@ -579,7 +574,7 @@ function set_up_project_alternatives(
         PA_fs_dict[PA.uid] = create_PA_aggregated_fs(PA_subprojects[PA.uid])
 
         # Save raw project fs results, if verbose outputs are enabled
-        if convert.(Bool, verbose_outputs)
+        if verbosity > 2
             CSV.write(
                 joinpath(
                     "tmp",

--- a/src/agent.py
+++ b/src/agent.py
@@ -145,10 +145,6 @@ class GenCo(Agent):
             )
             sysimage_cmd = f"-J {sysimage_path}"
 
-        vo_string = ""
-        if self.model.args.verbose_outputs:
-            vo_string = "--verbose_outputs=1"
-
         julia_env = Path(os.getenv("ABCE_ENV"))
 
         julia_cmd = (
@@ -160,7 +156,6 @@ class GenCo(Agent):
             + f"--settings_file={self.model.args.settings_file} "
             + f"--inputs_path={self.model.args.inputs_path} "
             + f"--abce_abs_path={self.model.settings['file_paths']['ABCE_abs_path']} "
-            + vo_string
         )
 
         sp = subprocess.check_call(julia_cmd, shell=True)

--- a/src/agent_choice.jl
+++ b/src/agent_choice.jl
@@ -187,7 +187,7 @@ function run_agent_choice()
         CLI_args["current_pd"],
         C2N_specs,
         dispatch_results,
-        CLI_args["verbose_outputs"],
+        CLI_args["verbosity"],
     )
 
     # Update the agent's baseline projected financial statements, to use in

--- a/src/model.py
+++ b/src/model.py
@@ -58,7 +58,7 @@ class GridModel(Model):
         self.load_all_data()
 
         # Ensure a tmp directory exists inside the current working directory
-        if self.args.verbose_outputs:
+        if self.args.verbosity > 2:
             self.ensure_tmp_dir_exists()
 
         # If running A-LEAF, set up any necessary file paths


### PR DESCRIPTION
This PR links the existing `verbosity` command-line setting to verbose saving of outputs to the `abce/tmp` directory. This applies or will apply to such files as:

* Project alternatives' projected financial statements
* Dispatch results from dispatch.jl

These extra outputs are only saved for verbosity level 3 (the maximum supported level).