### PR TITLE
Removing deprecated tests

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -22,6 +22,4 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - run: |
-        bash ./test/run_julia_tests.sh
 


### PR DESCRIPTION
Certain tests no longer match the internal methods of `dispatch.jl`; removing these from the github action