### PR TITLE
Improving the handling of energy shortages in the dispatch.jl module

### DIFF
--- a/settings.yml
+++ b/settings.yml
@@ -77,7 +77,6 @@ system:
   tax_rate: 0.21
   planning_reserve_margin: 0.1375
   peak_initial_reserves: 0.0
-  max_total_ENS: 100000  # MWh, allowed gen. undersupply in first projected dispatch year (Energy Not Served)
 
 # Settings for demand projections
 demand:

--- a/src/dispatch.jl
+++ b/src/dispatch.jl
@@ -891,6 +891,12 @@ function run_annual_dispatch(
     # Solve the integral optimization problem
     m, status, gen_qty, r, sr, nsr, c, su, sd, s = solve_model(m, model_type = "integral")
 
+    # Set up default return values if the dispatch year is infeasible
+    new_grc_results = nothing
+    new_prices = nothing
+    run_next_year = false
+    total_ENS = nothing
+
     if status == "OPTIMAL"
         # Save the generation and commitment results from the integral problem
         new_grc_results = assemble_grc_results(y, gen_qty, r, sr, nsr, c, su, sd, portfolio_specs)


### PR DESCRIPTION
This PR includes multiple bugfixes and improvements to the `dispatch.jl` module and associated processes.

## Fix to handling of energy not served (ENS) in the objective function

ENS is defined in the model as the difference between hourly load (a fixed input) and generation supplied; i.e. it is the slack variable for generation. Previously, ENS was incorrectly multiplied by the generation cost coefficient (VOM + fuel cost + policy adjustments). It was also included inside the summation over unit types, which meant that it was penalized excessively by the generation cost coefficient and then multiplied by the number of units in the system.

$` minimize \sum_{i} \left[ \sum_{d} \sum_{h} \left( gen(i, d, h) + ENS(d, h) \cdot X_{ENS} \right) \cdot (VOM_{i}+ ....) + ... \right]`$

ENS should be applied system-wide on an hourly basis--that is, it belongs inside the summations over day and hour, but outside the summation over unit type. This PR corrects the formulation of the objective function to reflect this.

$` minimize \sum_{i} \left[ \sum_{d} \sum_{h} \left( gen(i, d, h) \cdot (VOM_{i}+ ....) + ... \right)+ ENS(d, h) \cdot X_{ENS} \right] `$

This incorrect formulation caused the model to enter degenerate conditions of critical capacity undersupply. This combined with the next issue, hard ENS limits, to cause frequent premature model failures during the parametric study.

## Removal of hard ENS limits

Previously, one user-supplied parameter was the maximum total ENS allowed for each simulated dispatch year. This was used to identify degenerate conditions of critical capacity undersupply: in an earlier version of the model, agents had no ability to "imagine" future capacity additions by their competitors, so agents tended to significantly underpredict the available capacity in future years, especially 8+ years in the future.

This maximum ENS limit was mostly implemented to identify points in time when this static capacity assumption became completely unreasonable, i.e. when the agent began to predict extreme capacity shortages that were unlikely to occur in reality. Once the dispatch module reached a year in which the maximum ENS limit made the problem infeasible, the model would assume that all future years would also be infeasible due to this misprediction problem. The dispatch simulation would then end, and the latest successful dispatch simulation would be used as the terminal dispatch results prediction for all remaining years.

However, since then, a better agent capacity prediction algorithm has been implemented, so that agents are less likely to make these pathological severe capacity underpredictions. Furthermore, in the modeled system, ERCOT, capacity undersupply is a real risk: due to historic low prices and lack of any capacity market, ERCOT has seen relatively little dispatchable/thermal generation capacity added over the last five years, and energy shortages occurred in summer 2023 (milder) and February 2021 (severe). So a predicted or even current condition of significant capacity insufficiency is not necessarily an unrealistic result.

This PR removes all hard limits on ENS. ENS is still heavily penalized in the optimization objective function, and non-zero ENS causes electricity prices to hit their cap of $9000/MWh, which should incentivize addition of new capacity to capture that market share.

