### PR TITLE
Improving treatment of net tax and tax credits

### DIFF
--- a/settings.yml
+++ b/settings.yml
@@ -77,7 +77,7 @@ system:
   tax_rate: 0.21
   planning_reserve_margin: 0.1375
   peak_initial_reserves: 0.0
-  tax_credits_sale_haircut: 0.1
+  tax_credits_discount: 0.1
 
 # Settings for demand projections
 demand:

--- a/settings.yml
+++ b/settings.yml
@@ -77,6 +77,7 @@ system:
   tax_rate: 0.21
   planning_reserve_margin: 0.1375
   peak_initial_reserves: 0.0
+  tax_credits_sale_haircut: 0.1
 
 # Settings for demand projections
 demand:

--- a/src/ABCEfunctions.jl
+++ b/src/ABCEfunctions.jl
@@ -2297,13 +2297,10 @@ function compute_accounting_line_items(db, agent_fs, agent_params)
     tax_rate = tax_rate[1, :value]
 
     # Compute nominal tax owed
-    transform!(agent_fs, :EBT => ((EBT) -> EBT * tax_rate) => :tax_owed)
+    transform!(agent_fs, :EBT .=> ByRow(EBT -> ifelse(EBT >= 0, EBT * tax_rate, 0)) .=> :tax_owed)
 
     # Net Income
-    transform!(
-        agent_fs,
-        [:EBT, :tax_credits, :tax_owed] => ((EBT, tax_credits, tax) -> (EBT - tax + tax_credits)) => :net_income,
-    )
+    transform!(agent_fs, [:EBT, :tax_owed, :tax_credits] => ((EBT, T, C) -> EBT - T + C) => :net_income)
 
     # Free Cash Flow
     transform!(

--- a/src/model.py
+++ b/src/model.py
@@ -357,10 +357,15 @@ class GridModel(Model):
         prm = self.settings["system"]["planning_reserve_margin"]
         self.cur.execute(f"INSERT INTO model_params VALUES ('PRM', {prm})")
 
+
         tax_rate = self.settings["system"]["tax_rate"]
         self.cur.execute(
             f"INSERT INTO model_params VALUES ('tax_rate', {tax_rate})"
         )
+
+        tax_credits_discount = self.settings["system"]["tax_credits_discount"]
+        self.cur.execute(f"INSERT INTO model_params VALUES ('tax_credits_discount', {tax_credits_discount})")
+
         self.db.commit()
 
     def step(self, demo=False):


### PR DESCRIPTION
This PR improves the treatment of overall tax and tax credit monetization.

## Requiring total corporate tax to be nonnegative

For an individual project, the net impact on tax can be negative in a given year if the project's taxable income is negative during that year. This condition indicates that the project would reduce the firm's total tax burden during that year.

However, the total tax burden of the firm cannot be less than zero. This PR updates the tax calculation function to allow negative net tax if the financial statement is for a project, while requiring non-negative net tax if the financial statement is for the agent as a whole.

## Modeling monetization of tax credits

A firm can only directly redeem tax credits up to its actual tax burden. Excess tax credits can be monetized by selling them on to a third party, but the total value gained from the transaction is only a fraction of the credits' face value. Furthermore, sale of excess tax credit counts as taxable income.

This PR updates the consideration of tax credits in the agent's financial statement to cap them at the agent's total tax burden for each particular year. Excess credits are sold for a user-specified fraction of their face value (current default: 90%), and the revenue is converted to an after-tax basis by multiplying by $`(1 - r_{tax})`$.