### PR TITLE
Fixing indexing error in routine determining valid possible coal retirements

### DIFF
--- a/settings.yml
+++ b/settings.yml
@@ -6,7 +6,7 @@ simulation:
   C2N_assumption: baseline
 
 scenario:
-  peak_demand: 75000
+  peak_demand: 78000
   policies:
     CTAX:
       enabled: False
@@ -112,9 +112,9 @@ agent_opt:
   credit_rating_lamda: 0.1
   fin_metric_horizon: 6
   int_bound: 5.0
-  icr_floor: 1.0
-  fcf_debt_floor: 0.05
-  re_debt_floor: 0.03
+  icr_floor: 4.2
+  fcf_debt_floor: 0.2
+  re_debt_floor: 0.15
 
 financing:
   default_debt_term: 30

--- a/src/ABCEfunctions.jl
+++ b/src/ABCEfunctions.jl
@@ -1660,7 +1660,7 @@ function set_up_model(
     end
 
     for i = 1:size(coal_retirements)[2]
-        y = current_pd + i - 1
+        y = current_pd + i - 1  # -1 converts i from julia dataframe index back to true relative year
         num_units = 0
 
         # Get number of planned coal units operating during this period

--- a/src/ABCEfunctions.jl
+++ b/src/ABCEfunctions.jl
@@ -1660,7 +1660,7 @@ function set_up_model(
     end
 
     for i = 1:size(coal_retirements)[2]
-        y = current_pd + i
+        y = current_pd + i - 1
         num_units = 0
 
         # Get number of planned coal units operating during this period
@@ -1916,7 +1916,7 @@ function record_asset_retirements(
                 db,
                 string(
                     "SELECT asset_id FROM assets WHERE unit_type = ? ",
-                    "AND retirement_pd = ? AND agent_id = ?",
+                    "AND retirement_pd = ? AND agent_id = ? AND C2N_reserved = 0",
                 ),
                 match_vals,
             ) |> DataFrame


### PR DESCRIPTION
This PR corrects an indexing issue where an incorrect number of coal units were being counted as valid targets for retirement under certain circumstances.