### PR TITLE
Implementing fixes to coal retirement filtering and C2N project schedules

### DIFF
--- a/inputs/unit_specs.yml
+++ b/inputs/unit_specs.yml
@@ -300,6 +300,7 @@ PWR_C2N0_single:
   is_VRE: False
   uses_fuel: True
   occ_stdev: 0
+  construction_duration: 6
   const_dur_stdev: 0
   unit_life: 60
   num_cpp_rets: 1
@@ -336,6 +337,7 @@ PWR_C2N1_single:
   is_VRE: False
   uses_fuel: True
   occ_stdev: 0
+  construction_duration: 7
   const_dur_stdev: 0
   unit_life: 60
   num_cpp_rets: 1
@@ -372,6 +374,7 @@ HTGR_C2N0_single:
   is_VRE: False
   uses_fuel: True
   occ_stdev: 0
+  construction_duration: 6
   const_dur_stdev: 0
   unit_life: 60
   num_cpp_rets: 1
@@ -408,6 +411,7 @@ HTGR_C2N2_single:
   is_VRE: False
   uses_fuel: True
   occ_stdev: 0
+  construction_duration: 7
   const_dur_stdev: 0
   unit_life: 60
   num_cpp_rets: 1
@@ -444,6 +448,7 @@ SFR_C2N0_single:
   is_VRE: False
   uses_fuel: True
   occ_stdev: 0
+  construction_duration: 6
   const_dur_stdev: 0
   unit_life: 60
   num_cpp_rets: 1
@@ -480,6 +485,7 @@ SFR_C2N3_single:
   is_VRE: False
   uses_fuel: True
   occ_stdev: 0
+  construction_duration: 6
   const_dur_stdev: 0
   unit_life: 60
   num_cpp_rets: 1

--- a/src/ABCEfunctions.jl
+++ b/src/ABCEfunctions.jl
@@ -869,28 +869,14 @@ function forecast_capex(
     C2N_specs,
     fs_copy,
 )
-    if occursin("C2N", subproject["unit_type"])
-        capex_timeline, activity_schedule = project_C2N_capex(
-            db,
-            settings,
-            unit_type_data,
-            subproject["lag"],
-            size(fs_copy)[1],
-            current_pd,
-            C2N_specs,
-        )
-        capex_timeline = capex_timeline[!, :total_capex]
-    else
-        capex_per_pd = (
-            unit_type_data[:overnight_capital_cost] *
-            unit_type_data[:capacity] *
-            settings["constants"]["MW2kW"] /
-            unit_type_data[:construction_duration]
-        )
-        capex_timeline =
-            ones(convert(Int64, unit_type_data[:construction_duration])) *
-            capex_per_pd
-    end
+    capex_per_pd = (
+        unit_type_data[:overnight_capital_cost] *
+        unit_type_data[:capacity] *
+        settings["constants"]["MW2kW"] /
+        unit_type_data[:construction_duration]
+    )
+    capex_timeline =
+        ones(convert(Int64, unit_type_data[:construction_duration])) * capex_per_pd
 
     head_zeros = zeros(subproject["lag"])
     tail_zeros =
@@ -926,10 +912,10 @@ function project_C2N_capex(
         data = deepcopy(C2N_specs[conversion_type][rxtr_type])
 
     else
-        if unit_type_data[:unit_type] == "C2N1"
+        if occursin("C2N1", unit_type_data[:unit_type])
             conversion_type = "electrical"
             rxtr_type = "PWR"
-        elseif unit_type_data[:unit_type] == "C2N2"
+        elseif occursin("C2N2", unit_type_data[:unit_type])
             conversion_type = "steam_noTES"
             rxtr_type = "HTGR"
         else
@@ -957,7 +943,6 @@ function project_C2N_capex(
     )
 
     return capex_tl, activity_schedule
-
 end
 
 

--- a/src/C2N_projects.jl
+++ b/src/C2N_projects.jl
@@ -44,6 +44,16 @@ function create_C2N_capex_timeline(
         asset_id = nothing,
     )
 
+    continue_checking = true
+    while continue_checking
+        if capex_tl[size(capex_tl)[1], :total_capex] == 0
+            deleteat!(capex_tl, size(capex_tl)[1])
+        else
+            continue_checking = false
+        end
+    end
+
+    return capex_tl, activity_schedule
 end
 
 

--- a/src/agent_choice.jl
+++ b/src/agent_choice.jl
@@ -101,10 +101,6 @@ function run_agent_choice()
     # Read in some raw data from the database
     agent_params, unit_specs = get_raw_db_data(db, CLI_args)
 
-    # Ensure all C2N projects have a valid construction duration
-    unit_specs =
-        ABCEfunctions.validate_project_data(db, settings, unit_specs, C2N_specs)
-
     # Retrieve a list of the agent's currently-operating assets, grouped by
     #   type and mandatory retirement date
     grouped_agent_assets = ABCEfunctions.get_grouped_current_assets(


### PR DESCRIPTION
This PR implements a few bugfixes for various project scheduling-related items.

### Coal retirement filtering and assignment
This PR adds better capabilities for assigning eligible-for-retirement CPPs to C2N projects. This prevents occasional bugs in which suboptimal matching between C2N projects and CPPs results in a situation where the last C2Ns to be matched have no eligible targets left. This would usually happen if late-retiring C2Ns are processed first, leaving C2Ns requiring early availability of a CPP without any valid target for the replacement.

### C2N project scheduling
This PR disables the custom C2N project scheduling utility. C2N projects will use the standard uniform expenditure profile assumed by other construction projects, until it is re-enabled. See Issue #106 for details. This PR also includes a few minor bugfixes within `C2N_projects.jl`.

### Bugfixes throughout
This PR also includes a few minor bugfixes.