### PR TITLE
Implementing optional direct simulation of annual dispatch

### DIFF
--- a/settings.yml
+++ b/settings.yml
@@ -2,7 +2,7 @@ simulation:
   scenario_name: "ABCE_run"
   solver: "HiGHS"
   num_steps: 1
-  annual_dispatch_engine: none
+  annual_dispatch_engine: ABCE
   C2N_assumption: baseline
 
 scenario:

--- a/src/agent_choice.jl
+++ b/src/agent_choice.jl
@@ -167,7 +167,9 @@ function run_agent_choice()
         fc_pd,
         demand_forecast,
         unit_specs,
-        adj_system_portfolios,
+        adj_system_portfolios;
+        run_mode="forecast",
+        downselection_mode=settings["dispatch"]["downselection"]
     )
 
     if CLI_args["verbosity"] > 2

--- a/src/annual_dispatch.jl
+++ b/src/annual_dispatch.jl
@@ -1,0 +1,133 @@
+using ArgParse, Logging, YAML, DataFrames, CPLEX, CSV, SQLite
+
+include(joinpath(ENV["ABCE_DIR"], "src", "ABCEfunctions.jl"))
+using .ABCEfunctions
+
+include(joinpath(ENV["ABCE_DIR"], "src", "dispatch.jl"))
+using .Dispatch
+
+function get_CL_args()
+    s = ArgParseSettings()
+    @add_arg_table s begin
+        "--current_pd"
+        help = "current simulation period"
+        required = true
+        arg_type = Int
+
+        "--settings_file"
+        help = "absolute path to the settings file"
+        required = false
+        default = joinpath(ENV["ABCE_DIR"], "settings.yml")
+
+        "--inputs_path"
+        help = "absolute path to the input files"
+        required = false
+        default = joinpath(ENV["ABCE_DIR"], "inputs")
+    end
+
+    return parse_args(s)
+end
+
+
+function show_header()
+    @info "==============================="
+    @info "ABCE dispatch simulation module"
+    @info "==============================="
+end
+
+
+function get_settings(CL_args)
+    # Retrieve settings
+    settings = YAML.load_file(CL_args["settings_file"])
+
+    return settings
+end
+
+function get_db(settings)
+    # Load database
+    db_file = joinpath(
+        ENV["ABCE_DIR"], 
+        "outputs",
+        settings["simulation"]["scenario_name"], 
+        settings["file_paths"]["db_file"],
+    )
+    db = ABCEfunctions.load_db(db_file)
+
+    return db
+end
+
+function get_unit_specs(db)
+    sql_cmd = "SELECT * FROM unit_specs"
+    unit_specs = DBInterface.execute(db, sql_cmd) |> DataFrame
+
+    return unit_specs
+end
+
+
+function get_year_portfolio(db, current_pd, unit_specs)
+    brief_unit_specs = unit_specs[!, [:unit_type, :capacity, :capacity_factor]]
+
+    sql_cmd = string(
+        "SELECT unit_type, COUNT(unit_type) FROM assets ",
+        "WHERE completion_pd <= $current_pd AND retirement_pd > $current_pd ",
+        "AND cancellation_pd > $current_pd GROUP BY unit_type",
+    )
+
+    system_portfolio = DBInterface.execute(db, sql_cmd) |> DataFrame
+
+    # Tidy up column names
+    rename!(system_portfolio, Symbol("COUNT(unit_type)") => :num_units)
+
+    # Add a column to indicate that all units are real
+    system_portfolio[!, :real] = ones(size(system_portfolio)[1])
+    system_portfolio[!, :esc_num_units] = system_portfolio[!, :num_units]
+
+    # Join in the unit specs data
+    system_portfolio = innerjoin(system_portfolio, brief_unit_specs, on = :unit_type)
+
+    # Compute total capacity
+    transform!(system_portfolio, [:num_units, :capacity] => ((num_units, cap) -> num_units .* cap) => :total_capacity)
+
+    system_portfolio_dict = Dict()
+
+    system_portfolio_dict[current_pd] = system_portfolio
+
+    return system_portfolio_dict
+end
+
+
+function run_true_annual_dispatch()
+    show_header()
+
+    @info "Setting up data..."
+    CL_args = get_CL_args()
+    settings = get_settings(CL_args)
+    db = get_db(settings)
+    unit_specs = get_unit_specs(db)
+    total_demand = ABCEfunctions.get_demand_forecast(db, CL_args["current_pd"], 1, settings)
+    system_portfolio_dict = get_year_portfolio(db, CL_args["current_pd"], unit_specs)
+
+    @info "Running the year-long dispatch simulation (this may take a little while)..."
+    # Run the year's UC/ED problem
+    long_econ_results, dispatch_results = Dispatch.execute_dispatch_economic_projection(
+        CL_args,
+        db,
+        settings,
+        1,   # forecast period is always 1 for current-year runs
+        total_demand,
+        unit_specs,
+        system_portfolio_dict;
+        run_mode="current",
+        downselection_mode="exact"
+    )
+
+    # Adjust formatting and save to the database
+    Dispatch.finalize_annual_dispatch_results(db, CL_args["current_pd"], dispatch_results)
+
+    @info "Done!"
+
+    CSV.write("./long_econ_results.csv", long_econ_results)
+    CSV.write("./dispatch_results.csv", dispatch_results)
+end
+
+run_true_annual_dispatch()   

--- a/src/dispatch.jl
+++ b/src/dispatch.jl
@@ -50,7 +50,7 @@ function execute_dispatch_economic_projection(
     )
 
     if downselection_mode == "exact"
-        ts_data = load_ts_data(ts_data_dir)
+        ts_data = load_ts_data(ts_data_dir, num_repdays=365)
     else
         ts_data = load_ts_data(
             ts_data_dir,

--- a/src/dispatch.jl
+++ b/src/dispatch.jl
@@ -312,7 +312,7 @@ function set_up_load_repdays(downselection_mode, num_days, num_hours, ts_data)
     else
         for day in ts_data[:repdays_data][!, :Day]
             load_repdays[!, Symbol(day)] =
-                ts_data[:load_data][(num_hours * day + 1):(num_hours * (day + 1)), :Load]
+                ts_data[:load_data][(num_hours * (day-1) + 1):(num_hours * day), :Load]
         end
     end
 
@@ -843,7 +843,7 @@ function run_annual_dispatch(
     downselection_mode="scenario_reduction"
 )
     # Set up the appropriate scenario reduction parameters
-    if mode == "current"
+    if run_mode == "current"
         num_days = 365
         num_hours = 24
     else
@@ -1205,6 +1205,12 @@ function postprocess_results(
         summarize_dispatch_results(settings, unit_specs, long_econ_results)
 
     return long_econ_results, dispatch_results
+end
+
+
+function finalize_annual_dispatch_results(db, current_pd, dispatch_results)
+    pivot = unstack(dispatch_results, :unit_type, :dispatch_result, :qty)
+    println(pivot)
 
 end
 

--- a/src/model.py
+++ b/src/model.py
@@ -418,7 +418,9 @@ class GridModel(Model):
             logging.log(self.settings["constants"]["vis_lvl"], "\n")
             user_response = input("Press Enter to continue: ")
 
-        if self.settings["simulation"]["annual_dispatch_engine"] == "ALEAF":
+        dispatch_engine = self.settings["simulation"]["annual_dispatch_engine"]
+
+        if dispatch_engine in ["ALEAF", "aleaf", "A-LEAF", "a-leaf"]:
             # Re-load the baseline A-LEAF data
             ALEAF_data = idm.load_data(
                 Path(self.args.inputs_path)
@@ -444,21 +446,33 @@ class GridModel(Model):
             ALEAF_sysimage_path = (
                 Path(os.environ["ALEAF_DIR"]) / "aleafSysimage.so"
             )
-            aleaf_cmd = (
+            dispatch_cmd = (
                 f"julia --project={ALEAF_env_path} "
                 + f"-J {ALEAF_sysimage_path} {run_script_path} "
                 + f"{self.settings['ALEAF']['ALEAF_abs_path']}"
             )
 
-            if self.args.verbosity < 2:
-                sp = subprocess.check_call(
-                    aleaf_cmd, shell=True, stdout=open(os.devnull, "wb")
-                )
-            else:
-                sp = subprocess.check_call(aleaf_cmd, shell=True)
+        elif dispatch_engine in ["ABCE", "abce"]:
+            ABCE_ENV = Path(os.environ["ABCE_ENV"])
+            annual_disp_script_path = Path(os.environ["ABCE_DIR"]) / "src" / "annual_dispatch.jl"
+            dispatch_cmd = (
+                f"julia --project={ABCE_ENV} {annual_disp_script_path} " 
+                + f"--current_pd={self.current_pd}"
+            )
 
+        # Run the dispatch simulation
+        if self.args.verbosity < 2:
+            sp = subprocess.check_call(
+                dispatch_cmd, shell=True, stdout=open(os.devnull, "wb")
+            )
+        else:
+            sp = subprocess.check_call(dispatch_cmd, shell=True)
+
+        # Save data to its final destination, if needed
+        if dispatch_engine in ["ALEAF", "aleaf", "A-LEAF", "a-leaf"]:
             self.save_ALEAF_outputs()
             self.process_ALEAF_dispatch_results()
+
 
     def display_step_header(self):
         if self.current_pd != 0:

--- a/src/model.py
+++ b/src/model.py
@@ -437,7 +437,7 @@ class GridModel(Model):
                 self.current_pd,
             )
 
-            # Run A-LEAF
+            # Set up the command to execute ALEAF
             logging.log(
                 self.settings["constants"]["vis_lvl"], "Running A-LEAF..."
             )
@@ -453,6 +453,7 @@ class GridModel(Model):
             )
 
         elif dispatch_engine in ["ABCE", "abce"]:
+            # Set up the command to run dispatch.jl in annual exact mode
             ABCE_ENV = Path(os.environ["ABCE_ENV"])
             annual_disp_script_path = Path(os.environ["ABCE_DIR"]) / "src" / "annual_dispatch.jl"
             dispatch_cmd = (
@@ -957,7 +958,7 @@ class GridModel(Model):
 
         # Get list of column names for ordering
         cursor = self.db.cursor().execute(
-            "SELECT * FROM ALEAF_dispatch_results"
+            "SELECT * FROM annual_dispatch_results"
         )
         col_names = [description[0] for description in cursor.description]
 

--- a/src/seed_creator.py
+++ b/src/seed_creator.py
@@ -240,13 +240,13 @@ abce_tables = {
         ("allowed", "text"),
         ("units_to_execute", "integer"),
     ],
-    "ALEAF_dispatch_results": [
+    "annual_dispatch_results": [
         ("period", "integer"),
         ("unit_type", "text"),
         ("generation", "real"),
-        ("reg_total", "real"),
-        ("spin_total", "real"),
-        ("nspin_total", "real"),
+        ("regulation", "real"),
+        ("spinning_reserve", "real"),
+        ("nonspinning_reserve", "real"),
         ("gen_rev", "real"),
         ("reg_rev", "real"),
         ("spin_rev", "real"),


### PR DESCRIPTION
Previously, ABCE could either use A-LEAF for the full-year time-series dispatch simulation, or have no annual dispatch (in which case, agents would assume their forecasts of the immediately upcoming year were correct).

This PR implements an option for ABCE's own `dispatch.jl` module to handle the full-year dispatch and market simulation problem, and return results to the database in the same format as A-LEAF would. This allows collection of more accurate historical data for use in the agents' economic forecasts.

This capability is invoked in `settings.yml`, by setting the `"simulation" > "annual_dispatch_engine"` value to `ABCE` instead of `none` or `ALEAF`. Use of this option is now the suggested user default.

This PR also changes numerous references to A-LEAF in variable and function names to the more generic `annual_dispatch`, to reflect the fact that A-LEAF is no longer the sole annual dispatch option..