### PR TITLE
Changing constraint to limit the weighted financial score instead of individual financial metrics

### DIFF
--- a/inputs/agent_specifications.yml
+++ b/inputs/agent_specifications.yml
@@ -8,7 +8,7 @@
     debt_fraction: 0.5
     cost_of_debt: 0.06
     cost_of_equity: 0.12
-    starting_debt: 7976000000
+    starting_debt: 7226000000
     starting_PPE:  1692000000
     starting_RE: 1110000000
     starting_portfolio:
@@ -190,7 +190,7 @@
     debt_fraction: 0.5
     cost_of_debt: 0.04
     cost_of_equity: 0.1
-    starting_debt:  4000000000
+    starting_debt:  3000000000
     starting_PPE:    600000000
     starting_RE: 1000000000
     starting_portfolio:

--- a/src/ABCEfunctions.jl
+++ b/src/ABCEfunctions.jl
@@ -1521,27 +1521,29 @@ function set_up_model(
     # Prevent the agent from reducing its aggregated financial metrics score
     #   below the weighted sum of the Moody's Ba rating thresholds (from the 
     #   Unregulated Power Companies ratings grid)
+    # Getting some values for conciseness
+    ICR_floor = settings["agent_opt"]["icr_floor"]
+    CDR_floor = settings["agent_opt"]["fcf_debt_floor"]
+    RCDR_floor = settings["agent_opt"]["re_debt_floor"]
+
     if mode == "normal"
         for i = 1:settings["agent_opt"]["fin_metric_horizon"]
             @constraint(
                 m,
                 0.1 * (
-                    agent_fs[i, :FCF] / 1e9 +
-                    sum(u .* marg_FCF[:, i]) +
-                    (1 - settings["agent_opt"]["icr_floor"]) * (
-                        agent_fs[i, :interest_payment] / 1e9 +
-                        sum(u .* marg_int[:, i])
+                    agent_fs[i, :FCF] / 1e9 + sum(u .* marg_FCF[:, i])
+                    + (1 - ICR_floor) * (agent_fs[i, :interest_payment] / 1e9 + sum(u .* marg_int[:, i])
                     )
                 )
 
                 + 0.2 * (
                     (agent_fs[i, :FCF] / 1e9 + sum(u .* marg_FCF[:, i])) 
-                    - settings["agent_opt"]["fcf_debt_floor"] * (agent_fs[i, :remaining_debt_principal] / 1e9 + sum(u .* marg_debt[:, i])) 
+                    - CDR_floor * (agent_fs[i, :remaining_debt_principal] / 1e9 + sum(u .* marg_debt[:, i])) 
                 )
 
                 + 0.1 * (
                     (agent_fs[i, :retained_earnings] / 1e9 + sum(u .* marg_retained_earnings[:, i])) 
-                    - settings["agent_opt"]["re_debt_floor"] * (agent_fs[i, :remaining_debt_principal] / 1e9 + sum(u .* marg_debt[:, i]))
+                    - RCDR_floor * (agent_fs[i, :remaining_debt_principal] / 1e9 + sum(u .* marg_debt[:, i]))
                 )
 
                 >= 0

--- a/src/ABCEfunctions.jl
+++ b/src/ABCEfunctions.jl
@@ -1499,9 +1499,6 @@ function set_up_model(
     end
 
     
-
-
-
     # Create arrays of expected marginal debt, interest, dividends, and FCF
     #   per unit type
     marg_debt = zeros(num_alternatives, num_time_periods)
@@ -1521,33 +1518,33 @@ function set_up_model(
     end
 
 
-    # Prevent the agent from reducing its credit metrics below Moody's B
-    #   rating thresholds (from the Unregulated Power Companies ratings grid)
+    # Prevent the agent from reducing its aggregated financial metrics score
+    #   below the weighted sum of the Moody's Ba rating thresholds (from the 
+    #   Unregulated Power Companies ratings grid)
     if mode == "normal"
         for i = 1:settings["agent_opt"]["fin_metric_horizon"]
-            # Interest coverage ratio
             @constraint(
                 m,
-                (
+                0.1 * (
                     agent_fs[i, :FCF] / 1e9 +
                     sum(u .* marg_FCF[:, i]) +
                     (1 - settings["agent_opt"]["icr_floor"]) * (
                         agent_fs[i, :interest_payment] / 1e9 +
                         sum(u .* marg_int[:, i])
                     )
-                ) >= 0
-            )
+                )
 
-            # FCF / debt
-            @constraint(
-                m,
-                (agent_fs[i, :FCF] / 1e9 + sum(u .* marg_FCF[:, i])) - settings["agent_opt"]["fcf_debt_floor"] * (agent_fs[i, :remaining_debt_principal] / 1e9 + sum(u .* marg_debt[:, i])) >= 0
-            )
+                + 0.2 * (
+                    (agent_fs[i, :FCF] / 1e9 + sum(u .* marg_FCF[:, i])) 
+                    - settings["agent_opt"]["fcf_debt_floor"] * (agent_fs[i, :remaining_debt_principal] / 1e9 + sum(u .* marg_debt[:, i])) 
+                )
 
-            # Retained earnings / debt
-            @constraint(
-                m,
-                (agent_fs[i, :retained_earnings] / 1e9 + sum(u .* marg_retained_earnings[:, i])) - settings["agent_opt"]["re_debt_floor"] * (agent_fs[i, :remaining_debt_principal] / 1e9 + sum(u .* marg_debt[:, i])) >= 0
+                + 0.1 * (
+                    (agent_fs[i, :retained_earnings] / 1e9 + sum(u .* marg_retained_earnings[:, i])) 
+                    - settings["agent_opt"]["re_debt_floor"] * (agent_fs[i, :remaining_debt_principal] / 1e9 + sum(u .* marg_debt[:, i]))
+                )
+
+                >= 0
             )
         end
     end


### PR DESCRIPTION
This PR updates the constraints in the agent decision optimization problem. Previously, each individual financial metric was constrained to its floor value from the user settings, but this was overly restrictive and artificially limited agents' ability to take positive action. This PR consolidates those three constraints into a single constraint, disallowing the weighted sum of those scores from falling below the weighted sum of the user-set floor values.

This significantly reduces the price oscillations in the model, because supply is less constrained as the agents can start new construction without prices needing to rise to ridiculous levels.

This PR also updates the starting debt values for agents 201 and 206, based on testing. In the base case, these two agents lose a significant fraction of their market share due to financial constraints. This behavior isn't very interesting, so reducing their starting debt levels allows them to be more active and competitive in the long term.