### PR TITLE
Updated constraints

### DIFF
--- a/settings.yml
+++ b/settings.yml
@@ -1,7 +1,7 @@
 simulation:
-  scenario_name: "ABCE_run"
+  scenario_name: "CTAX_0_NG_3"
   solver: "CPLEX"
-  num_steps: 1
+  num_steps: 20
   annual_dispatch_engine: ABCE
   C2N_assumption: baseline
 
@@ -105,7 +105,7 @@ dispatch:
 
 # Settings for agent behavior optimization
 agent_opt:
-  num_future_periods_considered: 4    # Number of periods for which to consider future projects
+  num_future_periods_considered: 2    # Number of periods for which to consider future projects
   max_type_rets_per_pd: 3
   max_type_newcap_per_pd: 1100
   shortage_protection_period: 8
@@ -116,9 +116,13 @@ agent_opt:
   credit_rating_lamda: 0.1
   fin_metric_horizon: 6
   int_bound: 5.0
-  icr_floor: 4.2
-  fcf_debt_floor: 0.2
-  re_debt_floor: 0.15
+  icr_floor: 3.5   # weighted sum limit
+  fcf_debt_floor: 0.16   # weighted sum limit
+  re_debt_floor: 0.115   # weighted sum limit
+  icr_solo_floor: -10000.00   # individual
+  fcf_debt_solo_floor: -10000.00   # individual
+  re_debt_solo_floor: -10000.00    # individual
+  
 
 financing:
   default_debt_term: 30

--- a/src/postprocessing.py
+++ b/src/postprocessing.py
@@ -67,7 +67,10 @@ def write_raw_db_to_excel(settings, db):
             table_data = pd.read_sql_query(f"SELECT * FROM {table}", db)
 
             # Write table data to excel tab
-            table_data.to_excel(writer, sheet_name=table, engine="openpyxl")
+            try:
+                table_data.to_excel(writer, sheet_name=table, engine="openpyxl")
+            except:
+                logging.info(f"Unable to save table {table} to excel, likely due to excessive length.")
 
 
 ###############################################################################


### PR DESCRIPTION
This PR separates the financial score constraints into two sets:

1. A floor on the aggregated financial score
2. Floors on the individual metrics

The default floors for the individual metrics are -10000 (effectively no floor). The default floor for the aggregated financial score represents the halfway point between the Baa minimums and the Ba minimums.

The floor constraint on the aggregated financial scores has also been updated to be appropriately weighted by the respective floor values.

This PR also updates some default settings values, and adds a try-catch block to solve an issue with overly-large database tables failing to save to xlsx.