### PR TITLE
Updating financial constraint weights to allow negative values

### DIFF
--- a/src/ABCEfunctions.jl
+++ b/src/ABCEfunctions.jl
@@ -1536,17 +1536,17 @@ function set_up_model(
             # Limit aggregated score
             @constraint(
                 m,
-                0.1 / ICR_floor * (
+                0.1 / abs(ICR_floor) * (
                     agent_fs[i, :FCF] / 1e9 + sum(u .* marg_FCF[:, i])
                     + (1 - ICR_floor) * (agent_fs[i, :interest_payment] / 1e9 + sum(u .* marg_int[:, i]))
                 )
 
-                + 0.2 / CDR_floor * (
+                + 0.2 / abs(CDR_floor) * (
                     (agent_fs[i, :FCF] / 1e9 + sum(u .* marg_FCF[:, i])) 
                     - CDR_floor * (agent_fs[i, :remaining_debt_principal] / 1e9 + sum(u .* marg_debt[:, i])) 
                 )
 
-                + 0.1 / RCDR_floor * (
+                + 0.1 / abs(RCDR_floor) * (
                     (agent_fs[i, :retained_earnings] / 1e9 + sum(u .* marg_retained_earnings[:, i])) 
                     - RCDR_floor * (agent_fs[i, :remaining_debt_principal] / 1e9 + sum(u .* marg_debt[:, i]))
                 )


### PR DESCRIPTION
Previously, the three terms in the weighted financial score term were weighted by both the Moody's contribution fractions and the value of the floor itself. Since one of the terms has a floor value of about 4 and the others have floor values around 0.2, the difference in magnitude would cause the overall result of the constraint to excessively hinge on the term with larger values, if each term were not weighted by $1 / floor_value$.

The individual financial scores can sometimes have valid negative values. It's also sometimes of interest to have negative floor values, particularly to simulate "no constraint", for which I usually use -10000 to simulation -infinity. However, putting negative values in the weights caused the constraint to be infeasible (since the total LHS of the constraint must be greater than or equal to zero).

This PR updates the floor-value weights to use the absolute value of the floor. This allows -inf floor values without changing behavior when more normal (i.e. positive) floor values are used.