### PR TITLE
Remove "dead" agents from the execution order

### DIFF
--- a/src/model.py
+++ b/src/model.py
@@ -391,9 +391,10 @@ class GridModel(Model):
             f"SELECT agent_id, COUNT(asset_id) FROM assets WHERE completion_pd <= {self.current_pd} AND retirement_pd > {self.current_pd} GROUP BY agent_id",
             self.db
         )
-        for agent_id in units_this_year["agent_id"]:
-            if units_this_year[units_this_year["agent_id"] == agent_id]["COUNT(asset_id)"].values[0] == 0:
-                self.schedule.remove(self.agents[int(agent_id)])
+        for agent_id, agent in self.agents.items():
+            if (str(agent_id) not in units_this_year.agent_id.values) and (self.agents[agent_id] in self.schedule.agents):
+                logging.info(f"Removing agent {agent_id} from the simulation due to a size-zero portfolio.")
+                self.schedule.remove(self.agents[agent_id])
 
         # Compute the scenario reduction results for this year
         ABCE.execute_scenario_reduction(

--- a/src/model.py
+++ b/src/model.py
@@ -385,6 +385,16 @@ class GridModel(Model):
         # Update financial statements and financial projections for all agents
         self.update_agent_financials()
 
+        # If any agent will have an empty portfolio this year, delete them
+        #   from the schedule
+        units_this_year = pd.read_sql_query(
+            f"SELECT agent_id, COUNT(asset_id) FROM assets WHERE completion_pd <= {self.current_pd} AND retirement_pd > {self.current_pd} GROUP BY agent_id",
+            self.db
+        )
+        for agent_id in units_this_year["agent_id"]:
+            if units_this_year[units_this_year["agent_id"] == agent_id]["COUNT(asset_id)"].values[0] == 0:
+                self.schedule.remove(self.agents[int(agent_id)])
+
         # Compute the scenario reduction results for this year
         ABCE.execute_scenario_reduction(
             self.args, self.db, self.current_pd, self.settings, self.unit_specs


### PR DESCRIPTION
This PR adds a couple of fixes to prevent "dead" (zero portfolio) agents from crashing the simulation.

Before each round of agent turns, but after all asset updates are executed, the GridModel object will now check whether any agents have zero active assets in the current period. If so, those agents are removed from the agent turn scheduler, thus skipping their decision turn for the rest of the simulation. (This also means that agents which drop to 0 active capacity are permanently disabled even if they have construction projects underway. However, this situation is not likely to occur.)

Additionally, if an agent is forecast to have zero active capacity in upcoming turns within the retirement protection horizon, ABCE would previously crash. Now, `ABCEfunctions.jl` check whether non-zero capacity is forecast to exist before generating the retirement adequacy constraint, preventing this crash mode.