### PR TITLE
Restructuring the set_up_model function in ABCEfunctions.jl

### DIFF
--- a/inputs/unit_specs.yml
+++ b/inputs/unit_specs.yml
@@ -232,7 +232,7 @@ PUN_unit_low:
   FOM: 11.39    # $/kW-yr
   VOM: 100.00    # $/MWh
   fuel_type: natural_gas
-  FC_per_MMBTU: 4.0
+  FC_per_MMBTU: 3.0
   no_load_cost: 0.0
   start_up_cost: 20.00   # $/MW
   shut_down_cost: 5.00  # $/MW, non-fuel start-up costs
@@ -267,7 +267,7 @@ PUN_unit_high:
   FOM: 11.39    # $/kW-yr
   VOM: 500.00    # $/MWh
   fuel_type: natural_gas
-  FC_per_MMBTU: 4.0
+  FC_per_MMBTU: 3.0
   no_load_cost: 0.0
   start_up_cost: 20.00   # $/MW
   shut_down_cost: 5.00  # $/MW, non-fuel start-up costs
@@ -391,7 +391,7 @@ PWR_C2N0_single:
   const_dur_stdev: 0
   unit_life: 60
   num_cpp_rets: 1
-  cpp_ret_lead: 2
+  cpp_ret_lead: 6
   ATB_search_settings:
     Tech: Nuclear
     TechDetail: "*"
@@ -465,7 +465,7 @@ HTGR_C2N0_single:
   const_dur_stdev: 0
   unit_life: 60
   num_cpp_rets: 1
-  cpp_ret_lead: 0
+  cpp_ret_lead: 6
   ATB_search_settings:
     Tech: Nuclear
     TechDetail: "*"
@@ -539,7 +539,7 @@ SFR_C2N0_single:
   const_dur_stdev: 0
   unit_life: 60
   num_cpp_rets: 1
-  cpp_ret_lead: 4
+  cpp_ret_lead: 6
   ATB_search_settings:
     Tech: Nuclear
     TechDetail: "*"

--- a/run.py
+++ b/run.py
@@ -110,6 +110,13 @@ def cli_args():
         action="store_true",
         help="Disable plot generation during postprocessing (prevents matplotlib/qt issues)",
     )
+    parser.add_argument(
+        "--log_file",
+        type=str,
+        help="Relative path to the desired logfile.",
+        default=Path(Path.cwd() / "logfile.txt"),
+    )
+
 
     args = parser.parse_args()
     return args
@@ -139,9 +146,13 @@ def initialize_logging(args, vis_lvl):
 
     fmt = ABCEFormatter(vis_lvl)
     hdlr = logging.StreamHandler(sys.stdout)
+    f_hdlr = logging.FileHandler(args.log_file)
 
     hdlr.setFormatter(fmt)
+    f_hdlr.setFormatter(fmt)
+
     logging.root.addHandler(hdlr)
+    logging.root.addHandler(f_hdlr)
 
     logging.root.setLevel(lvl)
 

--- a/src/agent.py
+++ b/src/agent.py
@@ -156,6 +156,7 @@ class GenCo(Agent):
             + f"--settings_file={self.model.args.settings_file} "
             + f"--inputs_path={self.model.args.inputs_path} "
             + f"--abce_abs_path={self.model.settings['file_paths']['ABCE_abs_path']} "
+            + f"2>&1 | tee -a {self.model.args.log_file}"
         )
 
         sp = subprocess.check_call(julia_cmd, shell=True)

--- a/src/agent_choice.jl
+++ b/src/agent_choice.jl
@@ -212,6 +212,7 @@ function run_agent_choice()
     @info "Setting up the agent's decision optimization problem..."
     m = ABCEfunctions.set_up_model(
         settings,
+        CLI_args,
         PA_uids,
         PA_fs_dict,
         demand_forecast,
@@ -228,7 +229,7 @@ function run_agent_choice()
 
     # Solve the model
     @info "Solving optimization problem..."
-    optimize!(m)
+    m = ABCEfunctions.solve_model(m)
 
     status = string(termination_status.(m))
     if status == "OPTIMAL"
@@ -237,6 +238,7 @@ function run_agent_choice()
     else
         m_ret = ABCEfunctions.set_up_model(
             settings,
+            CLI_args,
             PA_uids,
             PA_fs_dict,
             demand_forecast,


### PR DESCRIPTION
This PR modularizes the `set_up_model()` function in ABCEfunctions.jl, which sets up the optimization variables, constraints, and objective for the agent's main decision problem. This makes the function much more readable and maintainable. This PR also removes the redundant retirement constraints, by extending the previously C2N-specific maximum retirement time-series logic to cover all unit types.