### PR TITLE
Independently select representative days each year for all forecast years

### DIFF
--- a/src/ABCEfunctions.py
+++ b/src/ABCEfunctions.py
@@ -50,13 +50,13 @@ def get_next_asset_id(db, suggested_next_id):
     return next_id
 
 
-def execute_scenario_reduction(args, db, current_pd, settings, unit_specs):
+def execute_scenario_reduction(args, db, current_pd, fc_pd, settings, unit_specs):
     # Get the number of wind and solar units to allow computation of net
     #   demand
     current_portfolio = pd.read_sql_query(
         f"SELECT unit_type FROM assets "
-        + f"WHERE completion_pd <= {current_pd} "
-        + f"AND retirement_pd > {current_pd}",
+        + f"WHERE completion_pd <= {fc_pd} "
+        + f"AND retirement_pd > {fc_pd}",
         db,
     )
     num_wind = len(current_portfolio.loc[current_portfolio.unit_type == "wind"])
@@ -74,7 +74,7 @@ def execute_scenario_reduction(args, db, current_pd, settings, unit_specs):
 
     # Get peak demand for this period
     peak_demand = pd.read_sql_query(
-        f"SELECT demand FROM demand " + f"WHERE period = {current_pd}", db
+        f"SELECT demand FROM demand " + f"WHERE period = {fc_pd}", db
     ).iloc[0, 0]
 
     # Set up directory locations
@@ -107,6 +107,8 @@ def execute_scenario_reduction(args, db, current_pd, settings, unit_specs):
         windCapacity=num_wind * wind_cap + num_wind_old * wind_old_cap,
         solarCapacity=num_solar * solar_cap + num_solar_old * solar_old_cap,
         peakDemand=peak_demand,
+        current_pd=current_pd,
+        fc_pd=fc_pd
     )
 
 

--- a/src/model.py
+++ b/src/model.py
@@ -528,10 +528,18 @@ class GridModel(Model):
                 logging.info(f"Removing agent {agent_id} from the simulation due to a size-zero portfolio.")
                 self.schedule.remove(self.agents[agent_id])
 
-        # Compute the scenario reduction results for this year
-        ABCE.execute_scenario_reduction(
-            self.args, self.db, self.current_pd, self.settings, self.unit_specs
-        )
+        # Compute the scenario reduction results for the dispatch forecast
+        #   horizon, starting with this year
+        fc_horiz = self.settings["dispatch"]["num_dispatch_years"]
+        for fc_y in range(self.current_pd, self.current_pd + fc_horiz):
+            ABCE.execute_scenario_reduction(
+                self.args,
+                self.db,
+                self.current_pd,
+                fc_y,
+                self.settings,
+                self.unit_specs
+            )
 
         # Close the database to avoid access problems in the Julia scope
         self.db.commit()

--- a/src/scenario_reduction.py
+++ b/src/scenario_reduction.py
@@ -21,9 +21,6 @@ import os
 
 
 def run_scenario_reduction(**kwargs):
-
-    logging.debug("Running the scenario reduction algorithm...")
-
     # set default parameters and pars kwargs
     setting = {
         "time_resolution": "Hourly",
@@ -40,11 +37,15 @@ def run_scenario_reduction(**kwargs):
         "windCapacity": 1.0,
         "solarCapacity": 1.0,
         "peakDemand": 1.0,
+        "current_pd": 0,
+        "fc_pd": 0,
     }
 
     for key in setting.keys():
         if key in kwargs:
             setting[key] = kwargs[key]
+
+    logging.debug(f"Running the scenario reduction algorithm:\nBase year: {setting['current_pd']} | Forecast year: {setting['fc_pd']}")
 
     # Check input output folders
     for sc_dir in [
@@ -189,7 +190,8 @@ def run_scenario_reduction(**kwargs):
 
         rep_day_input_df.to_csv(
             os.path.join(
-                setting["data_output_path"], f"repDays_{str(num_scenarios)}.csv"
+                setting["data_output_path"],
+                f"bp_{setting['current_pd']}_fp_{setting['fc_pd']}_repDays_{str(num_scenarios)}.csv"
             ),
             index=False,
         )


### PR DESCRIPTION
Previously, ABCE used the current forecast year to generate a single set of representative days, which were used for all forecast years when simulating dispatch in the agents' decision algorithm. This led to significant mispredictions between years where significant amounts of capacity came online, as different sets of representative days would be selected and create differing results from the forecast. This would cause agents to "scramble" to meet the totally unforeseen revenue opportunity, resulting in artificially chunky investment decisions across the time horizon.

This PR updates ABCE to generate individual repday sequences at the start of every decision round for all years in the user-specified forecast horizon (default: 10 years). This fixes the market results forecasting issue, as test results show that revenue mispredictions between adjacent years no longer occur.