### PR TITLE
Adding toggle for file logging

### DIFF
--- a/settings.yml
+++ b/settings.yml
@@ -2,6 +2,7 @@ simulation:
   scenario_name: "baseline"
   solver: "CPLEX"
   num_steps: 1
+  file_logging_level: 1  # 0: no additional csvs saved; 1: all additional csvs saved
   annual_dispatch_engine: ABCE
   C2N_assumption: baseline
 

--- a/settings.yml
+++ b/settings.yml
@@ -2,7 +2,8 @@ simulation:
   scenario_name: "baseline"
   solver: "CPLEX"
   num_steps: 1
-  file_logging_level: 1  # 0: no additional csvs saved; 1: all additional csvs saved
+  file_logging_level: 0  # 0: no additional csvs saved; 1: all additional csvs saved
+                         # caution! enabling file logging with 365 repdays can require 200GB+ of storage
   annual_dispatch_engine: ABCE
   C2N_assumption: baseline
 

--- a/src/ABCEfunctions.jl
+++ b/src/ABCEfunctions.jl
@@ -610,7 +610,7 @@ function set_up_project_alternatives(
         PA_fs_dict[PA.uid] = create_PA_aggregated_fs(PA_subprojects[PA.uid])
 
         # Save raw project fs results, if verbose outputs are enabled
-        if (verbosity > 2) || (agent_id == 204) || (agent_id == "204") || true
+        if settings["simulation"]["file_logging_level"] > 0
             CSV.write(
                 joinpath(
                     settings["file_paths"]["output_logging_dir"],
@@ -1557,6 +1557,7 @@ function add_constraint_shortage_protection(
 end
 
 function compute_marginal_PA_contributions(
+        settings,
         verbosity,
         PA_summaries,
         PA_fs_dict,
@@ -1587,7 +1588,7 @@ function compute_marginal_PA_contributions(
     end
 
     # Record marginal contributions to csv if verbosity is set to max
-    if verbosity > 2
+    if settings["simulation"]["file_logging_level"] > 0
         # Write marg_debt to file
         CSV.write(
             joinpath(
@@ -2086,6 +2087,7 @@ function set_up_model(
 
     # Compute marginal cash flow/income statement contributions from all PAs
     marg_debt, marg_int, marg_FCF, marg_RE = compute_marginal_PA_contributions(
+        settings,
         CLI_args["verbosity"],
         PA_summaries,
         PA_fs_dict,


### PR DESCRIPTION
This PR adds a toggle to enable or disable logging of intermediate tabular data to csv files. With 7 agents and 365 repdays (no downselection), full logging can generate hundreds of GB of output data, so file logging is disabled by default.