### PR TITLE
Create and utilize realized financial statements for agents

### DIFF
--- a/src/ABCEfunctions.jl
+++ b/src/ABCEfunctions.jl
@@ -2761,6 +2761,9 @@ function compute_scheduled_financing_factors(db, agent_fs, agent_id, current_pd)
         Symbol("SUM(depreciation)") => :depreciation,
     )
 
+    # Replace all instances of 'missing' and NaN with 0.0
+    agent_fs = coalesce.(agent_fs, 0.0)
+
     return agent_fs
 end
 


### PR DESCRIPTION
This PR implements realized financial statements for agents.

Previously, agents would use prior years' forecasted financial statements as actuals. This could cause significant mismatch in the case of years where units are retired, typically leading to unrecorded financial benefits in the retirement year for agents as prices increase.

This PR implements calculation of actual financial statements based on the "true" annual dispatch performed for the system after all agent turns are complete. Based on their portfolio of operational (not WIP, not retired) assets, agents' financial results are calculated and recorded for future access.

Closes #134 in the project tracker.